### PR TITLE
Fix build after the removal of `make-coding-system`.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,13 +12,13 @@ NIIBE Yutaka <gniibe@fsij.org>
 	Wrote egg.el, menudiag.el, egg-cnv.el, egg-com.el,
 	and egg-mlh.el.
 	Wrote backend conversion engine interface:
-	    ANTHY: egg/anthy.el, egg/anthyipc.el, 
+	    ANTHY: egg/anthy.el, egg/anthyipc.el,
 	    SJ3: egg/sj3.el, egg/sj3rpc.el,
 	    WNN: egg/wnn.el, and egg/wnnrpc.el.
 
 KATAYAMA Yoshio <kate@pfu.co.jp>
 	Design ITS programming.
-	Wrote its/hangul.el, its/erpin.el, its/pinyin.el, 
+	Wrote its/hangul.el, its/erpin.el, its/pinyin.el,
 	its/thai.el, and its/zhuyin.el.
 
 Satoru Tomura <tomura@etl.go.jp>
@@ -28,5 +28,3 @@ Satoru Tomura <tomura@etl.go.jp>
 
 Hisashi Miyashita <himi@bird.scphys.kyoto-u.ac.jp>
 	Wrote CCL routines in tamago-com.el.
-
-

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,18 @@
+2016-05-15  Hiroki Sato <hrs@allbsd.org>
+
+	* configure.ac: Use standard AM_PATH_LISPDIR instead of
+	--with-lispdir and --with-emacs-cmd.  Add --enable-doc for
+	documentation.
+	* Makefile.am, configure.ac: Update build infrastructure to use
+	automake properly.
+	* egg.el: Fix warning about defgroup.
+	* egg-cnv.el: Fix warning about (buffer-has-markers-at).
+	* helper/Makefile.am: Compile helper binary only when necessary.
+	* check-jisx0213.el: Removed in favor of checking it directly in
+	the configure script.
+
 2016-05-14  Hiroki Sato <hrs@allbsd.org>
+
 	* Makefile.in: Add EMACS_CMD, datadir, datarootdir.  Use
 	${INSTALL_DATA} for multiple files at once.  Install gzip'd .el
 	files.

--- a/ChangeLog.1997-1998
+++ b/ChangeLog.1997-1998
@@ -1,4 +1,4 @@
-1998-07-12  NIIBE Yutaka  <gniibe@chroot.org>
+1998-07-12  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg-mlh.el (mlh-space-bar-backward-henkan): Don't test against
 	egg-conversion-backend-alist.
@@ -38,7 +38,7 @@
 	(egg-conversion-backend): Not buffer local.
 	(egg-finalize-backend-alist): Removed.
 
-1998-07-10  NIIBE Yutaka  <gniibe@chroot.org>
+1998-07-10  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg-cnv.el (egg-start-conversion-failure-hook): New Variable.
 	(egg-start-conversion-failure-fallback): New Function.
@@ -69,7 +69,7 @@
 	(its-set-interim-terminal-state): New Function.
 	(its-make-next-state): Remove 2nd argument KEYSEQ.
 
-1998-07-01  NIIBE Yutaka  <gniibe@chroot.org>
+1998-07-01  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg-mlh.el (mlh-hira-to-kata): Removed.  Doesn't work any more.
 	(mlh-katakana): Use japanese-katakana-region.
@@ -80,7 +80,7 @@
 
 	* egg-cnv.el (egg-abort-conversion): Bug fix.
 
-1998-06-27  NIIBE Yutaka  <gniibe@akebono>
+1998-06-27  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg/wnn.el (wnn-dictionary-specification-list): Don' specify
 	for gerodic/g-jinmei.
@@ -212,19 +212,19 @@
 	* its/thai.el: New File.
 	* its/hangul.el: Updated.
 
-1998-06-26  NIIBE Yutaka  <gniibe@chroot.org>
+1998-06-26  NIIBE Yutaka <gniibe@fsij.org>
 
 	* Makefile (install): Don't touch .emacs and leim-list.el
 	directly.  User should do it by her hand.
 	Reported by SAKAI Kiyotaka <ksakai@netwk.ntt-at.co.jp>
 
-1998-06-25  NIIBE Yutaka  <gniibe@chroot.org>
+1998-06-25  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg/canna.el (canna-dictionary-specification): "user" instead of
 	("user").  Should chnage canna-filename later.
 	Reported by Akio Morita <amorita@bird.scphys.kyoto-u.ac.jp>.
 
-1998-04-02  NIIBE Yutaka  <gniibe@chroot.org>
+1998-04-02  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg-com.el (comm-unpack-u16-string): Call string-as-multibyte.
 	(comm-unpack-mb-string): Likewise.
@@ -249,13 +249,13 @@
 	* egg-mlh.el (mlh-space-bar-backward-henkan): activate input
 	method.
 
-1998-04-02  NIIBE Yutaka  <gniibe@chroot.org>
+1998-04-02  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg-cnv.el (egg-decide-bunsetsu): Undo changes of 03-16.
 	(egg-abort-conversion): Call egg-end-conversion.
 	(egg-decide-before-point): Call egg-end-conversion widh ABORT=NIL.
 
-1998-03-16  NIIBE Yutaka  <gniibe@chroot.org>
+1998-03-16  NIIBE Yutaka <gniibe@fsij.org>
 
 	CANNA Support.
 	* egg/canna.el, egg/cannarpc.el: New file.
@@ -267,7 +267,7 @@
 	EGG-END-CONVERSION.
 	* egg/sj3.el (sj3-end-conversion): Likewise.
 
-1998-03-15  NIIBE Yutaka  <gniibe@chroot.org>
+1998-03-15  NIIBE Yutaka <gniibe@fsij.org>
 
 	* Makefile: Add dependencies for its-keydef.elc.
 	* egg/sj3rpc.el (sj3-open): Don't support list of hosts.
@@ -423,7 +423,7 @@
 	* its/zenkaku.el: New file.
 	* its/zhuyin.el: New file.
 
-1998-03-14  NIIBE Yutaka  <gniibe@chroot.org>
+1998-03-14  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg/sj3rpc.el (sj3rpc-close): New function.
 
@@ -432,7 +432,7 @@
 	(sj3-end-conversion): Implement CLSTDY.
 	(sj3-fini): Implemented.
 
-1998-03-10  NIIBE Yutaka  <gniibe@chroot.org>
+1998-03-10  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg/sj3.el (sj3-end-conversion): Implement bunsetsu study.
 	CLSTDY not yet.
@@ -446,7 +446,7 @@
 	* egg-com.el (comm-format-u8-vector): New substitution.
 	(comm-format): New format 'v'.
 
-1998-03-09  NIIBE Yutaka  <gniibe@chroot.org>
+1998-03-09  NIIBE Yutaka <gniibe@fsij.org>
 
 	* docomp.el (its-keydef): Require its-keydef when compile.
 	Not so good.  Just a work around.
@@ -457,7 +457,7 @@
 	* its.el (its-translate-region): Make it command.
 	(its-translate-region-internal): Make it function.
 
-1998-03-04  NIIBE Yutaka  <gniibe@chroot.org>
+1998-03-04  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-define-select-keys of its-mode-map): Comment it out.
 	* its-keydef.el (its-make-select-func): Add eval-when to compile this.
@@ -567,13 +567,13 @@
 	(egg-exit-conversion): Use gg-decide-before-point.
 	(egg-abort-conversion): New command.
 
-1998-02-20  NIIBE Yutaka  <gniibe@akebono>
+1998-02-20  NIIBE Yutaka <gniibe@fsij.org>
 
 	* Makefile (SRCS), Egg.prj: Remove euc-china.el.
 	* egg-com.el: Include egg-china.el.
 	* egg-china.el: Removed.
 
-1998-02-18  NIIBE Yutaka  <gniibe@chroot.org>
+1998-02-18  NIIBE Yutaka <gniibe@fsij.org>
 
 	* Egg.prj: Use PRCS.
 
@@ -591,7 +591,7 @@
 	* egg/wnn.el (egg-activate-wnn): 
 	* egg/sj3.el (egg-activate-sj3): 
 	
-1998-02-17  NIIBE Yutaka  <gniibe@chroot.org>
+1998-02-17  NIIBE Yutaka <gniibe@fsij.org>
 
 	* Makefile (SRCS): Add its/pinyin.el, its/hangul.el and
 	its-keydef.el.
@@ -781,9 +781,9 @@
 1997-11-03  KATAYAMA Yoshio <kate@pfu.co.jp>
 
 	* euc-cn.el: New file.  Original name was yincoding.el.
-	Adopted by NIIBE Yutaka  <gniibe@chroot.org>.
+	Adopted by NIIBE Yutaka <gniibe@fsij.org>.
 	
-1997-11-03  NIIBE Yutaka  <gniibe@chroot.org>
+1997-11-03  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-start): Add INVISIBLE property if ITS-FENCE-FACE.
 	* egg-cnv.el (egg-decide-before-point): Ditto.
@@ -816,7 +816,7 @@
 	* egg.el, egg-mlh.el, egg-com.el, egg-cnv.el: Rename from tamago-*.el
 	* Makefile: Follow the changes.
 
-1997-10-05  NIIBE Yutaka  <gniibe@chroot.org>
+1997-10-05  NIIBE Yutaka <gniibe@fsij.org>
 
 	* tamago/wnn.el (wnn-uniq-candidates): Add new argument BUNSETSU.
 	Call WNN-BUNSETSU-SET-ZENKOUHO-POS, WNN-BUNSETSU-SET-ZENKOUHO in
@@ -827,21 +827,21 @@
 	* tamago-cnv.el (egg-next-candidate): Handle the case where
 	EGG-LIST-CANDIDATES returns non zero value.
 
-1997-10-04  NIIBE Yutaka  <gniibe@chroot.org>
+1997-10-04  NIIBE Yutaka <gniibe@fsij.org>
 
 	* Makefile (install): Install to SITEDIR.
 
-1997-09-26  NIIBE Yutaka  <gniibe@chroot.org>
+1997-09-26  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its/hira.el (its-hira-enable-zenkaku-alphabet): New variable.
 	(its-hira-map): Use it.
 
-1997-09-19  NIIBE Yutaka  <gniibe@chroot.org>
+1997-09-19  NIIBE Yutaka <gniibe@fsij.org>
 
 	Arrange for LEIM.  Use tamago/ subdirectory.
 	* tamago/: Rename from tamago-lib.
 
-1997-09-18  NIIBE Yutaka  <gniibe@chroot.org>
+1997-09-18  NIIBE Yutaka <gniibe@fsij.org>
 
 	* tamago-cnv.el (egg-select-candidate): menu-select -->
 	menudiag-select. 
@@ -864,7 +864,7 @@
 	* menudiag.el: Rename from menu.el.
 	(Throughout): Rename menu-* to menudiag-*.
 
-1997-09-07  NIIBE Yutaka  <gniibe@chroot.org>
+1997-09-07  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg.el (egg-insert-after-hook, egg-exit-hook): Removed.
 	(egg-sai-henkan-start, egg-sai-henkan-end, egg-old-bunsetu-suu):
@@ -898,7 +898,7 @@
 	(wnnenv-get-daibunsetsu-info, wnnenv-set-daibunsetsu-info): Likewise.
 	(wnn-create-environment, wnn-get-environment): Likewise.
 
-1997-09-04  NIIBE Yutaka  <gniibe@chroot.org>
+1997-09-04  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-state-machine-keyseq): Bug fix.  Handle VSYL.
 
@@ -908,7 +908,7 @@
 	* wnnrpc.el (wnnrpc-call-with-proc, wnnrpc-call-with-proc-1): Deleted.
 	Throughout: Use comm-call-with-proc and comm-call-with-proc-1.
 
-1997-09-03  NIIBE Yutaka  <gniibe@chroot.org>
+1997-09-03  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (wnnrpc-call-with-proc-1): Bug fix.  let --> progn.
 
@@ -928,7 +928,7 @@
 	* mlh.el (mlh-zenkaku): Use new API of Emacs-20,
 	japanese-zenkaku-region.
 
-1997-09-02  NIIBE Yutaka  <gniibe@chroot.org>
+1997-09-02  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg.el (egg-toroku-region): New function.
 
@@ -940,7 +940,7 @@
 	(wnnrpc-get-writable-dictionary-id-list): Rename from
 	wnnrpc-get-writable-dictionary-list.
 
-1997-09-01  NIIBE Yutaka  <gniibe@chroot.org>
+1997-09-01  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-decide-bunsetsu): New function.
 	(egg-decide-before-point): New command.
@@ -962,7 +962,7 @@
 	its-end-of-input-buffer, its-backward-SYL, its-forward-SYL,
 	its-delete-SYL): Follow the change.
 
-1997-08-31  NIIBE Yutaka  <gniibe@chroot.org>
+1997-08-31  NIIBE Yutaka <gniibe@fsij.org>
 
 	For egg-mode, don't use minor mode, override local map instead.
 	For its-mode and egg-conversion-mode, don't use minor mode,
@@ -982,7 +982,7 @@
 
 	* its.el (its-exit-mode-off-input-method): New function.
 
-1997-08-29  NIIBE Yutaka  <gniibe@chroot.org>
+1997-08-29  NIIBE Yutaka <gniibe@fsij.org>
 
 	Let Undo work correctly.
 	* its.el (its-self-insert-char): Delete/Insert cursor.
@@ -999,7 +999,7 @@
 	* its-pinyin.el: New file.
 	* its-zhuyin.el: New file.
 
-1997-08-28  NIIBE Yutaka  <gniibe@chroot.org>
+1997-08-28  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-exit-mode-no-egg): Removed.
 	(its-exit-mode-internal): Remove first argument.
@@ -1020,7 +1020,7 @@
 	(its-enter, its-left): New functions.
 	(its-mode): New variable.  New minor mode.
 
-1997-08-27  NIIBE Yutaka  <gniibe@chroot.org>
+1997-08-27  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-exit-conversion-no-egg): Removed.
 	(egg-exit-conversion): No argument, no egg-mode.
@@ -1029,14 +1029,14 @@
 	* its.el (its-exit-mode-internal): Follow it.
 	* mlh.el (mlh-space-bar-backward-henkan): Ditto.
 
-1997-08-26  NIIBE Yutaka  <gniibe@chroot.org>
+1997-08-26  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnn.el (wnn-change-bunsetsu-length): Don't use magic #3.
 
 	* convert.el (egg-insert-bunsetsu-list): Add optional argument
 	CONTIN.
 
-1997-08-25  NIIBE Yutaka  <gniibe@chroot.org>
+1997-08-25  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-insert-bunsetsu): Include seperator.  Add
 	intangible property to bunsetsu.
@@ -1049,7 +1049,7 @@
 	* mlh.el (mlh-space-bar-backward-henkan): Call egg-convert-region
 	with last argument t.  Turn of egg-mode.
 
-1997-08-24  NIIBE Yutaka  <gniibe@chroot.org>
+1997-08-24  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-exit-mode-internal): Inactivate input method.
 
@@ -1067,7 +1067,7 @@
 	(wnn-start-conversion): Don't call wnnenv-set-bunsetsu-list.
 	(wnn-end-conversion): Ditto.
 
-1997-08-23  NIIBE Yutaka  <gniibe@chroot.org>
+1997-08-23  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-change-bunsetsu-length): Change the interface.
 	(egg-shrink-bunsetsu,egg-enlarge-bunsetsu): Follow it.
@@ -1077,19 +1077,19 @@
 	(egg-select-candidate, egg-shrink-bunsetsu, egg-enlarge-bunsetsu,
 	egg-next-candidate): Use egg-get-previous-bunsetsu.
 
-1997-08-20  NIIBE Yutaka  <gniibe@chroot.org>
+1997-08-20  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg.el (minor-mode-alist): Don't show " EGG" in mode line.
 	(egg-mode): Use input method indicator instead.
 
-1997-07-20  NIIBE Yutaka  <gniibe@chroot.org>
+1997-07-20  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-next-candidate): Rename from egg-next-conversion.
 	(egg-previous-candidate): Rename from egg-previous-conversion.
 	(egg-select-candidate): Follow the change of new interface.
 	(egg-source-maxlen-from-here): Likewise.
 
-1997-07-19  NIIBE Yutaka  <gniibe@chroot.org>
+1997-07-19  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnn.el (wnn-start-conversion): Change the interface.  Return ENV
 	and the	list of bunsetsu.  Fix the documentation string too.
@@ -1113,7 +1113,7 @@
 	(wnnrpc-receive-sho-bunsetsu-list): Take ENV as the first argument.
 	(wnnrpc-renbunsetsu-conversion): Follow the change.
 
-1997-07-17  NIIBE Yutaka  <gniibe@chroot.org>
+1997-07-17  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-decide-candidate):  Change the interface.
 	Take the argument bunsetsu-info instead of conversion-engine.
@@ -1159,11 +1159,11 @@
 	* its.el (its-state-machine-keyseq, its-state-machine): Handle
 	end-of-input correctly when going backward.
 
-1997-07-16  NIIBE Yutaka  <gniibe@chroot.org>
+1997-07-16  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnn.el (wnn-create-directory): Bug fix.  Really make directory.
 
-1997-07-15  NIIBE Yutaka  <gniibe@chroot.org>
+1997-07-15  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its-hangul.el (its-define-hangul): Use its-defrule-otherwise.
 
@@ -1171,12 +1171,12 @@
 
 	* its-hangul.el: Updated.
 
-1997-06-19  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-06-19  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its-hira.el: its-hira-hankaku-escape --> its-hankaku-escape.
 	its-hira-zenkaku-escape --> its-zenkaku-escape.
 
-1997-06-14  NIIBE Yutaka  <gniibe@chroot.org>
+1997-06-14  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el: Change the data structure of <expr-output-back-list> so
  	that it can encourage sharing same structure and it can use same
@@ -1187,7 +1187,7 @@
 	(its-eob-keyexpr, its-eob-back, its-make-class+back,
  	its-make-otherwise): New substitutions.
 
-1997-06-13  NIIBE Yutaka  <gniibe@chroot.org>
+1997-06-13  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its-kana.el: New file.  Taken from its/kanainput.el of Mule-2.3.
 
@@ -1198,11 +1198,11 @@
 	(define-its-state-machine, define-its-state-machine-append): New
  	macro.
 
-1997-06-13  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-06-13  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its-hira.el ("n'"): Added.
 
-1997-06-12  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-06-12  NIIBE Yutaka <gniibe@fsij.org>
 
 	its-zenkaku-escape and its-hankaku-escape are also used in hangul.
 	* its.el (its-zenkaku-escape, its-hankaku-escape): Moved to here
@@ -1217,7 +1217,7 @@
 
 	* its-hangul.el: New file.
 
-1997-06-10  NIIBE Yutaka  <gniibe@chroot.org>
+1997-06-10  NIIBE Yutaka <gniibe@fsij.org>
 
 	Miscellaneous cosmetic changes.
 	* comm.el: New file.  Move communication related funcitons from
@@ -1243,7 +1243,7 @@
 
 	* egg.el: Comment out definition of C-\ in global-map.
 
-1997-06-09  NIIBE Yutaka  <gniibe@chroot.org>
+1997-06-09  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-kick-convert-region): Rename from its-convert-region.
 	(its-mode-map): Follow the change.
@@ -1260,7 +1260,7 @@
 
 	(its-goto-state): Tune up.
 
-1997-06-08  NIIBE Yutaka  <gniibe@chroot.org>
+1997-06-08  NIIBE Yutaka <gniibe@fsij.org>
 
 	* mlh.el: Merge mlh-nihongo.el.
 	* mlh-nihongo.el: Removed.
@@ -1309,7 +1309,7 @@
  	wnnrpc-unpack-bytes): Use it.  Use search-forward.
 	(wnnrpc-unpack-u16-string): Use decode-coding-region.
 
-1997-06-07  NIIBE Yutaka  <gniibe@chroot.org>
+1997-06-07  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnn.el (wnn-get-all-candidates): New function.
 	(wnn-set-bunsetsu-pos): Return 0 (instead of -1).
@@ -1320,14 +1320,14 @@
 	(egg-select-candidate): New function.
 	(egg-conversion-map): Bind "\M-s" and egg-select-candidate.
 
-1997-06-05  NIIBE Yutaka  <gniibe@chroot.org>
+1997-06-05  NIIBE Yutaka <gniibe@fsij.org>
 
 	* bushu.el: Renamed from busyu.el.
 	(bushu-break-string, etc): Renamed from busyu*.
 
 	* menu.el: Completely rewritten.
 
-1997-06-03  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-06-03  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-reset-start-state): Bug fix.  Delete a CDR.
 
@@ -1347,7 +1347,7 @@
 
 	* its/hira.el (n): Use its-define-otherwise.
 
-1997-06-02  NIIBE Yutaka  <gniibe@chroot.org>
+1997-06-02  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (wnnrpc-receive-sho-bunsetsu-list-sub,
  	wnnrpc-receive-sho-bunsetsu-list-sub-2): Splited from
@@ -1356,7 +1356,7 @@
 	(wnnrpc-daibunsetsu-conversion, wnnrpc-get-daibunsetsu-candidate): 
 	New function.
 
-1997-06-01  NIIBE Yutaka  <gniibe@chroot.org>
+1997-06-01  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (ccl-decode-fixed-euc-jp): Clean it up.
 	(wnnrpc-file-attribute): Rename from wnnrpc-stat-file.
@@ -1373,7 +1373,7 @@
  	wnnrpc-set-file-comment, wnnrpc-hinshi-name,
  	wnnrpc-set-file-password, wnnrpc-set-hinshi-table): New functions.
 
-1997-05-31  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-31  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (wnnrpc-format-u32c, wnnrpc-unpack-u32c): New
  	substitutions.  Support 32-bit number represented in cons cell of
@@ -1388,7 +1388,7 @@
 	(wnnrpc-call-with-proc-1): New macro.  Assume the buffer is the one
 	of process.
 
-1997-05-29  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-29  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (wnnrpc-get-conversion-parameters, wnnrpc-file-loaded,
  	wnnrpc-write-file, wnnrpc-get-fuzokugo-file, wnnrpc-get-file-list,
@@ -1406,7 +1406,7 @@
 	ccl-encode-fixed-euc): New private coding system.  Encode/decode
 	CCL for it.
 
-1997-05-27  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-27  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (wnnrpc-tanbunsetsu-conversion): Change the argument.
 	(wnnrpc-get-bunsetsu-candidates): Likewise.
@@ -1416,7 +1416,7 @@
 	(wnn-set-bunsetsu-pos): Likewise.
 	(wnn-change-bunsetsu-length, wnn-start-conversion): Likewise.
 
-1997-05-25  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-25  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (wnnrpc-add-word, wnnrpc-get-dictionary-list,
 	wnnrpc-receive-dictionary-list, wnnrpc-get-writable-dictionary-list,
@@ -1437,7 +1437,7 @@
  	wnn-open-frequency, wnn-query-del/create-frequency): New function.
 	(wnn-set-dictionary-sub): New function.
 
-1997-05-24  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-24  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (wnnrpc-version, wnnrpc-access, wnnrpc-mkdir,
  	wnnrpc-create-dictionary, wnnrpc-create-frequency, 
@@ -1457,7 +1457,7 @@
 	an error message for wnnrpc-set-fuzokugo-file on failure.
 	(wnn-set-dictionary): Handle return value.
 
-1997-05-17  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-17  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (wnnrpc-error-message): Error strings taken from
  	Wnn-4.2 distribution.
@@ -1480,7 +1480,7 @@
 	(wnn-get-environment): Follow the change.  On failure, don't
 	register the environment to wnn-environments.
 
-1997-05-16  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-05-16  NIIBE Yutaka <gniibe@fsij.org>
 
 	Dynamically allocate environment arbitrarily.
 	* wnn.el (wnn-create-environment): Change the structure of ENV.
@@ -1491,7 +1491,7 @@
 
 	* wnn.el (wnn-fini): Implemented.
 
-1997-05-15  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-15  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-start-conversion): Change the interface.
 	(egg-convert-region): Follow the change.
@@ -1503,7 +1503,7 @@
 	(wnn-connect-and-init): Removed.
 	(wnn-environments): New variable which holds all environments.
 
-1997-05-15  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-05-15  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnn.el (wnn-change-bunsetsu-length): Bug fix.  Last argument to
  	wnnrpc-b-set-freq-down is list of bunsetsu.
@@ -1519,7 +1519,7 @@
 
 	* its.el (its-defrule): New argument `enable-overwrite'.
 
-1997-05-14  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-14  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-exit-conversion-unread-char): Use newer variable
  	unread-command-events, as unread-command-char is obsolete.
@@ -1553,14 +1553,14 @@
 	* wnn.el (wnn-open): Change the name of WNN buffer as debug has
  	been done.
 
-1997-05-11  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-11  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el (wnnrpc-following-char-or-wait): Rename from
  	wnn-following-char-or-wait.
 	(wnnrpc-following-char-or-wait): Declare with DEFUN instead of
  	DEFSUBST.
 
-1997-05-10  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-10  NIIBE Yutaka <gniibe@fsij.org>
 
 	* Throughout: Use JUNET coding system for file format.
 
@@ -1581,7 +1581,7 @@
 
 	* mlh.el, nihongo.el: Taken from mlh-1.002 distribution.
 
-1997-05-07  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-07  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-update-frequency): Removed.
 	(egg-conversion-backend): Remove entry for update-frequency.
@@ -1590,11 +1590,11 @@
 	according to suggestion by Tomoko Yoshida in mule-jp@etl.go.jp.
 	Original had been taken from wnn-4.2.
 
-1997-05-06  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-06  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-next-conversion): Bug fix.  It's max+ instead of n.
 
-1997-05-05  NIIBE Yutaka  <gniibe@chroot.org>
+1997-05-05  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnfns.c (Fwnn_get_bunsetsu_converted): Rename from
 	get-converted-bunsetsu.
@@ -1605,11 +1605,11 @@
 	* wnn.el (wnn-create-environment): New file which mimics API of
 	wnnfns.c.
 
-1997-04-29  NIIBE Yutaka  <gniibe@chroot.org>
+1997-04-29  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnrpc.el: New file which implements Remote Procedure Calls of WNN.
 
-1997-04-16  NIIBE Yutaka  <gniibe@chroot.org>
+1997-04-16  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its/kanainput.el (normal-pair): Use its-defrule*.
 
@@ -1625,7 +1625,7 @@
 	(its-goto-state): New function.
 	(its-defrule, its-defoutput): Use its-goto-state.
 
-1997-04-12  NIIBE Yutaka  <gniibe@chroot.org>
+1997-04-12  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el: Enhance meaning of ITS state machine.  Now, <key>
  	includes representation of "ANY of key stroke" (-2).
@@ -1637,29 +1637,29 @@
  	its-k-symbols-escape): Add prefix its-.  Let them defconst.
 	"W": Move the definition beginning to avoid error.
 
-1997-03-26  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-26  NIIBE Yutaka <gniibe@fsij.org>
 
 	* convert.el (egg-next-conversion): -1 goes to end of bunsetsu.
 
-1997-03-25  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-25  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg.el (egg-mode-on, egg-input-mode, egg-in-fence-mode): Deleted.
 	(egg-fence-face-on, egg-fence-face-off): Deleted.
 	(egg-region-start, egg-region-end): Deleted.
 
-1997-03-24  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-24  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its/hira.el ("n"): Add "z" and "?" for prefetch char of "n".
 
 	Implement conversion mode.
 	* convert.el: New file.
 
-1997-03-23  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-23  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-mode-map): As "\C-g" is used in global-map, use
  	"\C-]" instead (for its-cancel-input).
 
-1997-03-22  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-22  NIIBE Yutaka <gniibe@fsij.org>
 
 	Introduce new scheme to specify server.
 	* wnnfns.c (Qjserver, Qcserver, Qtserver, Qkserver): Removed.
@@ -1672,7 +1672,7 @@
 	(Vwnn_uniqueness_specifier): Integer variable.  Renamed from
 	wnn_uniq_level.
 
-1997-03-21  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-21  NIIBE Yutaka <gniibe@fsij.org>
 
 	Cosmetic changes.
 	* wnnfnc.c (Throughout): Change Lisp function name to follow the
@@ -1710,7 +1710,7 @@
 
 	* egg-fence.el: Removed.
 
-1997-03-20  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-20  NIIBE Yutaka <gniibe@fsij.org>
 
 	Distingush continuation of egg-mode and turn off of egg-mode.
 	* its.el (its-mode-map): Bind "\C-\\" to its-exit-mode-no-egg.
@@ -1773,7 +1773,7 @@
  	its-move-nil-<--sub, its-move-nil-to-last, its-move-nil-to-first):
 	Deleted.
 
-1997-03-19  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-19  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el: Change the structure of DSYL.  Same as <state>.
 	(its-input-subsub): Follow the change of structure.
@@ -1789,7 +1789,7 @@
 
 	Introduce START, END and CURSOR.
 
-1997-03-19  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-03-19  NIIBE Yutaka <gniibe@fsij.org>
 
 	Global-map should be used, for key sequence not defined by
  	its-mode-map and/or egg-mode-map.   Don't mask other maps.
@@ -1798,7 +1798,7 @@
 	* egg.el (egg-mode-esc-map): Deleted.
 	(egg-mode-map): Include define-key of the esc-map here.
 	
-1997-03-18  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-18  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-input): Rename from its-input-input-buffer.
 	(its-state-machine): Handle END of input (key == -1).
@@ -1818,14 +1818,14 @@
 	(its-new-state, its-new-map): Split from its-new-state/map.
 	(its-make-map): Deleted.
 
-1997-03-17  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-17  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-buffer-insert-SYL-list): Use insert-and-inherit to
  	inherit properties.
 	(its-fence-overlay): Removed. Don't use overlay, as it has no
  	information in undo-list.
 
-1997-03-16  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-16  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its/hira.el ("n"): Use new feature END.
 	("ppy", "bby", "ddy", "jjy", "zzy", "ggy", "lly", "rry", "hhy",
@@ -1834,11 +1834,11 @@
 	* its.el (its-defrule): Add argument END.
 	(its-buffer-delete-SYL): Bug fix. Use length instead of string-width.
 
-1997-03-15  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-15  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-input-input-buffer): Implement the case of DSYL.
 
-1997-03-14  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-14  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-buffer-delete-SYL): Handle the case of NIL.
 
@@ -1846,7 +1846,7 @@
 	(digit-characters, symbol-characters, downcase-alphabets,
  	upcase-alphabets): Delete useless defvar-s.  
 
-1997-03-14  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-03-14  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its/hira.el ("roma-kana"): Follow change of implementation of
 	state machine.
@@ -1922,7 +1922,7 @@
 
 	* its.el (its-defrule-sub): Merged into its-defrule.
 
-1997-03-13  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-03-13  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el: (its-define-mode): Change the arguments.
 	* its/zhuyin.el ("zhuyin"): Follow the changes of its-define-mode.
@@ -1946,13 +1946,13 @@
 	* wnn6fns.c: New file.  Moved from wnnfns.c for WNN6 specific
  	functions.
 
-1997-03-12  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-12  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnnfns.c: cosmetic changes (indentation, commenting-out-style,
  	and compare to Qnil, etc).
 	Get rid of "register" qualifier.
 
-1997-03-05  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-05  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-define-mode): Change internal structure.  Completely
  	rewritten.
@@ -1990,7 +1990,7 @@
 	(its-make-non-terminal-state): Removed.  Not used.
 	(its-map-incrementalp, its-map-set-incrementalp): New functions.
 	
-1997-03-04  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-04  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-defrule-conditional, its-defrule-conditional*):
  	Removed.  Evaluating cond clause at runtime is stupid.  Rules
@@ -2031,7 +2031,7 @@
 	(its-defrule, its-defrule*): Remove MAP argument.
 	Merged into its-defrule.
 
-1997-03-04  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-03-04  NIIBE Yutaka <gniibe@fsij.org>
 
 	* its.el (its-completing-input-menu): Removed.  Not used.
 	(its-completing-input): Ditto.
@@ -2105,7 +2105,7 @@
 	(egg-fence-toggle-egg-mode): beep -> ding.
 	(global-map): bind C-\ to egg-enter-fence-mode.
 
-1997-03-02  NIIBE Yutaka  <gniibe@chroot.org>
+1997-03-02  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg-henkan.el: New file.
 
@@ -2183,7 +2183,7 @@
  	egg-fence-backward-delete-char): beep -> ding.
 	wnn-egg.el (egg-henkan-select-kouho): Likewise.
 
-1997-02-27  NIIBE Yutaka  <gniibe@chroot.org>
+1997-02-27  NIIBE Yutaka <gniibe@fsij.org>
 
 	* wnn-egg.el (push-end, push-end-internal): Removed.
 
@@ -2206,7 +2206,7 @@
 	* egg-jsymbol.el: lc-jp --> (charset-id 'japanese-jisx0208)
 	lc-jp2 --> (charset-id 'japanese-jisx0212).
 
-1997-02-26  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-02-26  NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg-fence.el (egg:fence-mode-map): Renamed from fence-mode-map.
 	(egg:fence-mode-esc-prefix): Renamed from egg:fence-mode-esc-map.
@@ -2306,6 +2306,6 @@
 	(henkan-region-internal): Use new API for marker insertion
  	`set-marker-insertion-type'.
 
-1997-02-13  NIIBE Yutaka  <gniibe@akebono.etl.go.jp>
+1997-02-13  NIIBE Yutaka <gniibe@fsij.org>
 
 	* menu.el (menu:select-from-menu): Rewritten.

--- a/ChangeLog.2002-2004
+++ b/ChangeLog.2002-2004
@@ -17,7 +17,7 @@
 	* Makefile.in (install-site): Put the .nosearch file into egg and
 	its subdirectories.
 
-2002-09-09  NIIBE Yutaka  <gniibe@m17n.org>
+2002-09-09  NIIBE Yutaka <gniibe@fsij.org>
 
 	Check JIS x0213 support at compile time.
 	* check-jisx0213.el: New file.
@@ -39,7 +39,7 @@
 	(ITSSRCS): Added its/greek.el
 	its/greek.elc: Depends on its-keydef.elc.
 
-2002-08-23  NIIBE Yutaka  <gniibe@m17n.org>
+2002-08-23  NIIBE Yutaka <gniibe@fsij.org>
 
 	* AUTHORS (NIIBE Yutaka): Updated.
 	* egg-mlh.el: Update e-mail address.
@@ -48,11 +48,11 @@
 	another" feature.
 	(egg-activate-anthy): Added.
 
-2002-08-23  Katsumi Yamaoka  <yamaoka@jpl.org>, NIIBE Yutaka  <gniibe@m17n.org>
+2002-08-23  Katsumi Yamaoka  <yamaoka@jpl.org>, NIIBE Yutaka <gniibe@fsij.org>
 
 	* egg-util.el: Removed.
 
-2002-08-08  NIIBE Yutaka  <gniibe@m17n.org>
+2002-08-08  NIIBE Yutaka <gniibe@fsij.org>
 
 	* Makefile.in (EGGSRCS): Added anthy.el and anthyipc.el
 	(srcdir, top_srcdir, VPATH): Added.

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 include $(top_srcdir)/elisp.mk
 
-SUBDIRS= egg its helper
+SUBDIRS= egg its @helper@
 
 lispdir= @lispdir@/egg
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -305,6 +305,7 @@ doc_DATA = @doc_DATA@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+helper = @helper@
 host_alias = @host_alias@
 htmldir = @htmldir@
 includedir = @includedir@
@@ -334,7 +335,7 @@ AM_ELCFLAGS = -q -no-site-file -no-init-file \
 		--eval="(setq load-path (append (list (expand-file-name \"$(top_srcdir)\")) load-path))" \
 		--eval="(load \"docomp.el\")"
 
-SUBDIRS = egg its helper
+SUBDIRS = egg its @helper@
 noinst_LISP = \
 	egg.el \
 	egg-edep.el \

--- a/Makefile.in
+++ b/Makefile.in
@@ -198,7 +198,7 @@ CSCOPE = cscope
 DIST_SUBDIRS = $(SUBDIRS)
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/config.h.in \
 	$(top_srcdir)/elisp.mk AUTHORS COPYING ChangeLog INSTALL NEWS \
-	README TODO compile depcomp install-sh missing
+	README TODO compile install-sh missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)

--- a/README.ja.txt
+++ b/README.ja.txt
@@ -1,7 +1,7 @@
 
 			   Tamago Version 4
 
-		   NIIBE Yutaka <gniibe@chroot.org>
+		   NIIBE Yutaka <gniibe@fsij.org>
 		   KATAYAMA Yoshio <kate@pfu.co.jp>
 		   TOMURA Satoru <tomura@etl.go.jp>
 

--- a/check-jisx0213.el
+++ b/check-jisx0213.el
@@ -1,3 +1,0 @@
-(if (charsetp 'japanese-jisx0213-1)
-    (kill-emacs 0)
-  (kill-emacs 1))

--- a/configure
+++ b/configure
@@ -589,6 +589,7 @@ am__EXEEXT_TRUE
 LTLIBOBJS
 LIBOBJS
 HAVE_JISX0213
+helper
 doc_DATA
 lispdir
 EMACSLOADPATH
@@ -3602,9 +3603,22 @@ fi
 
 
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking make-network-process" >&5
+$as_echo_n "checking make-network-process... " >&6; }
+if ${EMACS} -batch -q -no-site-file -no-init-file \
+  --eval="(if (fboundp 'make-network-process)(kill-emacs 0)(kill-emacs 1))";
+  then
+  echo "yes"; helper=""
+else
+  echo "no"; helper="helper"
+fi
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking jisx0213" >&5
 $as_echo_n "checking jisx0213... " >&6; }
-if ${EMACS} -batch -q -no-site-file -no-init-file -l ${srcdir}/check-jisx0213.el; then
+if ${EMACS} -batch -q -no-site-file -no-init-file \
+  --eval="(if (charsetp 'japanese-jisx0213-1)(kill-emacs 0)(kill-emacs 1))";
+  then
   echo "yes"; HAVE_JISX0213="aynu.el"
 else
   echo "no"; HAVE_JISX0213=""

--- a/configure.ac
+++ b/configure.ac
@@ -31,9 +31,22 @@ AC_ARG_ENABLE(doc,[AS_HELP_STRING([--disable-doc],
   echo "yes"; doc_DATA='${DOCS}')
 AC_SUBST(doc_DATA)
 
+dnl Check if (make-network-process) is supported or not
+AC_MSG_CHECKING(make-network-process)
+if ${EMACS} -batch -q -no-site-file -no-init-file \
+  --eval="(if (fboundp 'make-network-process)(kill-emacs 0)(kill-emacs 1))";
+  then
+  echo "yes"; helper=""
+else
+  echo "no"; helper="helper"
+fi
+AC_SUBST(helper)
+
 dnl Check if jisx0213 is supported or not
 AC_MSG_CHECKING(jisx0213)
-if ${EMACS} -batch -q -no-site-file -no-init-file -l ${srcdir}/check-jisx0213.el; then
+if ${EMACS} -batch -q -no-site-file -no-init-file \
+  --eval="(if (charsetp 'japanese-jisx0213-1)(kill-emacs 0)(kill-emacs 1))";
+  then
   echo "yes"; HAVE_JISX0213="aynu.el"
 else
   echo "no"; HAVE_JISX0213=""

--- a/docomp.el
+++ b/docomp.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>
 

--- a/egg-cnv.el
+++ b/egg-cnv.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999,2000 PFU LIMITED
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 ;;         KATAYAMA Yoshio <kate@pfu.co.jp>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>

--- a/egg-com.el
+++ b/egg-com.el
@@ -99,135 +99,38 @@
     (prog1 (- (point) pos)
       (goto-char pos))))
 
-(if (and (fboundp 'make-coding-system)
-         (null (get 'make-coding-system 'byte-obsolete-info)))
-;; since Emacs 23.1, make-coding-system has been marked as obsolete.
-    (eval-and-compile
-	(define-ccl-program ccl-decode-fixed-euc-jp
-	  `(2
-	    ((r2 = ,(charset-id 'japanese-jisx0208))
-	     (r3 = ,(charset-id 'japanese-jisx0212))
-	     (r4 = ,(charset-id 'katakana-jisx0201))
-	     (read r0)
-	     (loop
-	      (read r1)
-	      (if (r0 < ?\x80)
-		  ((r0 = r1)
-		   (if (r1 < ?\x80)
-		       (write-read-repeat r0))
-		   (write r4)
-		   (write-read-repeat r0))
-		((if (r1 > ?\x80)
-		     ((write r2 r0)
-		      (r0 = r1)
-		      (write-read-repeat r0))
-		   ((write r3 r0)
-		    (r0 = (r1 | ?\x80))
-		    (write-read-repeat r0)))))))))
-
-	(define-ccl-program ccl-encode-fixed-euc-jp
-	  `(2
-	    ((read r0)
-	     (loop
-	      (if (r0 == ,(charset-id 'latin-jisx0201))                   ; Unify
-		  ((read r0)
-		   (r0 &= ?\x7f)))
-	      (if (r0 < ?\x80)                                            ;G0
-		  ((write 0)
-		   (write-read-repeat r0)))
-	      (r6 = (r0 == ,(charset-id 'japanese-jisx0208)))
-	      (r6 |= (r0 == ,(charset-id 'japanese-jisx0208-1978)))
-	      (if r6                                                      ;G1
-		  ((read r0)
-		   (write r0)
-		   (read r0)
-		   (write-read-repeat r0)))
-	      (if (r0 == ,(charset-id 'katakana-jisx0201))                ;G2
-		  ((read r0)
-		   (write 0)
-		   (write-read-repeat r0)))
-	      (if (r0 == ,(charset-id 'japanese-jisx0212))                ;G3
-		  ((read r0)
-		   (write r0)
-		   (read r0)
-		   (r0 &= ?\x7f)
-		   (write-read-repeat r0)))
-	      (read r0)
-	      (repeat)))))
-	(make-coding-system 'fixed-euc-jp 4 ?W "Coding System for fixed EUC Japanese"
-			    (cons ccl-decode-fixed-euc-jp ccl-encode-fixed-euc-jp))
-	)
-    (eval-and-compile
-    ;; since Emacs 23.1, make-coding-system has been marked as obsolete.
-    ;; From Handa-san. [mule-ja : No.09414]
-    (define-charset 'fixed-euc-jp
-      "Fixed EUC Japanese"
-      :dimension 2
-      :superset '(ascii
-		  (katakana-jisx0201 . #x80)
-		  (japanese-jisx0208 . #x8080)
-		  (japanese-jisx0212 . #x8000)))
-    (define-coding-system 'fixed-euc-jp
-      "Coding System for fixed EUC Japanese"
-      :mnemonic ?W
-      :coding-type 'charset
-      :charset-list '(fixed-euc-jp))
-    )
+(eval-and-compile
+  (define-charset 'fixed-euc-jp
+    "Fixed EUC Japanese"
+    :dimension 2
+    :superset '(ascii
+		(katakana-jisx0201 . #x80)
+		(japanese-jisx0208 . #x8080)
+		(japanese-jisx0212 . #x8000)))
+  (define-coding-system 'fixed-euc-jp
+    "Coding System for fixed EUC Japanese"
+    :mnemonic ?W
+    :coding-type 'charset
+    :charset-list '(fixed-euc-jp))
   )
 
 ;; Korean
-
-(if (and (fboundp 'make-coding-system)
-         (null (get 'make-coding-system 'byte-obsolete-info)))
-;; since Emacs 23.1, make-coding-system has been marked as obsolete.
-    (eval-and-compile
-(define-ccl-program ccl-decode-fixed-euc-kr
-  `(2
-    ((r2 = ,(charset-id 'korean-ksc5601))
-     (read r0)
-     (loop
-      (read r1)
-      (if (r0 < ?\x80)
-	  (r0 = r1 & ?\x7f)
-	((write r2 r0)
-	 (r0 = r1 | ?\x80)))
-      (write-read-repeat r0)))))
-
-(define-ccl-program ccl-encode-fixed-euc-kr
-  `(2
-    ((read r0)
-     (loop
-      (if (r0 < ?\x80)
-	  ((write 0)
-	   (write-read-repeat r0)))
-      (if (r0 == ,(charset-id 'korean-ksc5601))
-	  ((read r0)
-	   (write r0)
-	   (read r0)
-	   (write-read-repeat r0)))
-      (read r0)
-      (repeat)))))
-(make-coding-system 'fixed-euc-kr 4 ?W "Coding System for fixed EUC Korean"
-		    (cons ccl-decode-fixed-euc-kr ccl-encode-fixed-euc-kr)))
-    (eval-and-compile
-    ;; since Emacs 23.1, make-coding-system has been marked as obsolete.
-    (define-charset 'fixed-euc-kr
-      "Fixed EUC Korean"
-      :dimension 2
-      :superset '(ascii
-		  (korean-ksc5601 . #x8080)))
-    (define-coding-system 'fixed-euc-kr
-      "Coding System for fixed EUC Korean"
-      :mnemonic ?W
-      :coding-type 'charset
-      :charset-list '(fixed-euc-kr))
-    )
-)
+(eval-and-compile
+  (define-charset 'fixed-euc-kr
+    "Fixed EUC Korean"
+    :dimension 2
+    :superset '(ascii
+		(korean-ksc5601 . #x8080)))
+  (define-coding-system 'fixed-euc-kr
+    "Coding System for fixed EUC Korean"
+    :mnemonic ?W
+    :coding-type 'charset
+    :charset-list '(fixed-euc-kr))
+  )
 
 
 ;; Chinese
 ;;
-;; TODO: convert an obsolete make-coding-system to define-coding-system.
 
 (defconst egg-pinyin-shengmu
   '((""  . 0)  ("B" . 1)  ("C"  . 2)  ("Ch" . 3)  ("D" . 4)
@@ -687,29 +590,33 @@ Return the length of resulting text."
 (defun post-read-decode-euc-zy-tw (len)
   (post-read-decode-fixed-euc-china len 'tw t))
 
-(make-coding-system 'fixed-euc-py-cn 0 ?W
-		    "Coding System for fixed EUC Chinese-gb2312")
+(define-coding-system
+  'fixed-euc-py-cn "Coding System for fixed EUC Chinese-gb2312"
+  :mnemonic ?W :coding-type 'emacs-mule)
 (coding-system-put 'fixed-euc-py-cn
 		   'pre-write-conversion 'pre-write-encode-euc-cn)
 (coding-system-put 'fixed-euc-py-cn
 		   'post-read-conversion 'post-read-decode-euc-py-cn)
 
-(make-coding-system 'fixed-euc-zy-cn 0 ?W
-		    "Coding System for fixed EUC Chinese-gb2312")
+(define-coding-system
+  'fixed-euc-zy-cn "Coding System for fixed EUC Chinese-gb2312"
+  :mnemonic ?W :coding-type 'emacs-mule)
 (coding-system-put 'fixed-euc-zy-cn
 		   'pre-write-conversion 'pre-write-encode-euc-cn)
 (coding-system-put 'fixed-euc-zy-cn
 		   'post-read-conversion 'post-read-decode-euc-zy-cn)
 
-(make-coding-system 'fixed-euc-py-tw 0 ?W
-		    "Coding System for fixed EUC Chinese-cns11643")
+(define-coding-system
+  'fixed-euc-py-tw "Coding System for fixed EUC Chinese-cns11643"
+  :mnemonic ?W :coding-type 'emacs-mule)
 (coding-system-put 'fixed-euc-py-tw
 		   'pre-write-conversion 'pre-write-encode-euc-tw)
 (coding-system-put 'fixed-euc-py-tw
 		   'post-read-conversion 'post-read-decode-euc-py-tw)
 
-(make-coding-system 'fixed-euc-zy-tw 0 ?W
-		    "Coding System for fixed EUC Chinese-cns11643")
+(define-coding-system
+  'fixed-euc-zy-tw "Coding System for fixed EUC Chinese-cns11643"
+  :mnemonic ?W :coding-type 'emacs-mule)
 (coding-system-put 'fixed-euc-zy-tw
 		   'pre-write-conversion 'pre-write-encode-euc-tw)
 (coding-system-put 'fixed-euc-zy-tw
@@ -735,8 +642,9 @@ Return the length of resulting text."
 	   (r0 = 0)))
       (write-read-repeat r0))))))
 
-(make-coding-system 'egg-binary 4 ?W "Coding System for binary data"
-		    (cons ccl-decode-egg-binary ccl-encode-egg-binary))
+(define-coding-system 'egg-binary "Coding System for binary data"
+  :mnemonic ?W :coding-type 'ccl :ccl-decoder ccl-decode-egg-binary
+  :ccl-encoder ccl-encode-egg-binary)
 
 
 (defun comm-format-u32c (uint32c)

--- a/egg-com.el
+++ b/egg-com.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
 ;; Author: Hisashi Miyashita <himi@bird.scphys.kyoto-u.ac.jp>
-;;         NIIBE Yutaka <gniibe@chroot.org>
+;;         NIIBE Yutaka <gniibe@fsij.org>
 ;;	   KATAYAMA Yoshio <kate@pfu.co.jp>  ; Korean, Chinese support.
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>

--- a/egg-edep.el
+++ b/egg-edep.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999,2000 PFU LIMITED
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 ;;         KATAYAMA Yoshio <kate@pfu.co.jp>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>

--- a/egg-mlh.el
+++ b/egg-mlh.el
@@ -3,10 +3,10 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@m17n.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 ;;         KATAYAMA Yoshio <kate@pfu.co.jp>      ; Multilingual Enhancement
 
-;; Maintainer: NIIBE Yutaka <gniibe@m17n.org>
+;; Maintainer: NIIBE Yutaka <gniibe@fsij.org>
 
 ;; Keywords: mule, multilingual, input method
 

--- a/egg-x0213.el
+++ b/egg-x0213.el
@@ -104,8 +104,10 @@
               (repeat)))
          (repeat)))))
 
-   (make-coding-system
-    'fixed-euc-jisx0213 4 ?W "Coding System for fixed EUC Japanese"
-    (cons ccl-decode-fixed-euc-jisx0213 ccl-encode-fixed-euc-jisx0213))))
+   (define-coding-system
+     'fixed-euc-jisx0213 "Coding System for fixed EUC Japanese"
+     :mnemonic ?W :coding-type 'ccl
+     :ccl-decoder ccl-decode-fixed-euc-jisx0213
+     :ccl-encoder ccl-encode-fixed-euc-jisx0213)))
 
 (provide 'egg-x0213)

--- a/egg.el
+++ b/egg.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 ;;         KATAYAMA Yoshio <kate@pfu.co.jp>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>

--- a/egg/Makefile.am
+++ b/egg/Makefile.am
@@ -14,6 +14,9 @@ noinst_LISP= \
 
 dist_lisp_LISP=	${noinst_LISP:.el=.el.gz} ${noinst_LISP:.el=.elc} .nosearch
 
+clean-local:
+	rm -f .nosearch wnn.el canna.el
+
 .nosearch:
 	touch $@
 wnn.el: wnn.el.in

--- a/egg/Makefile.am
+++ b/egg/Makefile.am
@@ -15,7 +15,7 @@ noinst_LISP= \
 dist_lisp_LISP=	${noinst_LISP:.el=.el.gz} ${noinst_LISP:.el=.elc} .nosearch
 
 clean-local:
-	rm -f .nosearch wnn.el canna.el
+	rm -f wnn.el canna.el
 
 .nosearch:
 	touch $@

--- a/egg/Makefile.in
+++ b/egg/Makefile.in
@@ -240,6 +240,7 @@ doc_DATA = @doc_DATA@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+helper = @helper@
 host_alias = @host_alias@
 htmldir = @htmldir@
 includedir = @includedir@

--- a/egg/Makefile.in
+++ b/egg/Makefile.in
@@ -584,7 +584,7 @@ uninstall-am: uninstall-dist_lispLISP uninstall-docDATA
 include ${top_srcdir}/elisp.mk
 
 clean-local:
-	rm -f .nosearch wnn.el canna.el
+	rm -f wnn.el canna.el
 
 .nosearch:
 	touch $@

--- a/egg/Makefile.in
+++ b/egg/Makefile.in
@@ -499,7 +499,7 @@ maintainer-clean-generic:
 	@echo "it deletes files that may require special tools to rebuild."
 clean: clean-am
 
-clean-am: clean-generic clean-lisp mostlyclean-am
+clean-am: clean-generic clean-lisp clean-local mostlyclean-am
 
 distclean: distclean-am
 	-rm -f Makefile
@@ -566,7 +566,7 @@ uninstall-am: uninstall-dist_lispLISP uninstall-docDATA
 .MAKE: install-am install-strip
 
 .PHONY: CTAGS GTAGS TAGS all all-am check check-am clean clean-generic \
-	clean-lisp cscopelist-am ctags ctags-am distclean \
+	clean-lisp clean-local cscopelist-am ctags ctags-am distclean \
 	distclean-generic distclean-tags distdir dvi dvi-am html \
 	html-am info info-am install install-am install-data \
 	install-data-am install-dist_lispLISP install-docDATA \
@@ -582,6 +582,9 @@ uninstall-am: uninstall-dist_lispLISP uninstall-docDATA
 .PRECIOUS: Makefile
 
 include ${top_srcdir}/elisp.mk
+
+clean-local:
+	rm -f .nosearch wnn.el canna.el
 
 .nosearch:
 	touch $@

--- a/egg/anthy.el
+++ b/egg/anthy.el
@@ -3,9 +3,9 @@
 
 ;; Copyright (C) 2002 The Free Software Initiative of Japan
 
-;; Author: NIIBE Yutaka <gniibe@m17n.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 
-;; Maintainer: NIIBE Yutaka <gniibe@m17n.org>
+;; Maintainer: NIIBE Yutaka <gniibe@fsij.org>
 ;;             Hideyuki SHIRAI <shirai@meadowy.org>
 
 ;; Keywords: mule, multilingual, input method

--- a/egg/anthyipc.el
+++ b/egg/anthyipc.el
@@ -3,9 +3,9 @@
 
 ;; Copyright (C) 2002 The Free Software Initiative of Japan
 
-;; Author: NIIBE Yutaka <gniibe@m17n.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 
-;; Maintainer: NIIBE Yutaka <gniibe@m17n.org>
+;; Maintainer: NIIBE Yutaka <gniibe@fsij.org>
 ;;             Hideyuki SHIRAI <shirai@meadowy.org>
 
 ;; Keywords: mule, multilingual, input method

--- a/egg/cannarpc.el
+++ b/egg/cannarpc.el
@@ -3,7 +3,7 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>
 

--- a/egg/sj3.el
+++ b/egg/sj3.el
@@ -3,7 +3,7 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>
 

--- a/egg/sj3rpc.el
+++ b/egg/sj3rpc.el
@@ -3,7 +3,7 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>
 

--- a/egg/wnnrpc.el
+++ b/egg/wnnrpc.el
@@ -3,7 +3,7 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 ;;         KATAYAMA Yoshio <kate@pfu.co.jp> ; Korean, Chinese support.
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>

--- a/helper/Makefile.in
+++ b/helper/Makefile.in
@@ -251,6 +251,7 @@ doc_DATA = @doc_DATA@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+helper = @helper@
 host_alias = @host_alias@
 htmldir = @htmldir@
 includedir = @includedir@

--- a/its.el
+++ b/its.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999,2000 PFU LIMITED
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 ;;         KATAYAMA Yoshio <kate@pfu.co.jp>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>

--- a/its/Makefile.in
+++ b/its/Makefile.in
@@ -245,6 +245,7 @@ doc_DATA = @doc_DATA@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+helper = @helper@
 host_alias = @host_alias@
 htmldir = @htmldir@
 includedir = @includedir@

--- a/its/hangul.el
+++ b/its/hangul.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999,2000 PFU LIMITED
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 ;;         KATAYAMA Yoshio <kate@pfu.co.jp>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>

--- a/its/hankata.el
+++ b/its/hankata.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>
 

--- a/its/hira.el
+++ b/its/hira.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>
 

--- a/leim-list.el
+++ b/leim-list.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999, 2000, 2002 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@m17n.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 ;;         KATAYAMA Yoshio <kate@pfu.co.jp>
 ;;         TOMURA Satoru <tomura@etl.go.jp>
 

--- a/menudiag.el
+++ b/menudiag.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 1999, 2000 Free Software Foundation, Inc
 
-;; Author: NIIBE Yutaka <gniibe@chroot.org>
+;; Author: NIIBE Yutaka <gniibe@fsij.org>
 
 ;; Maintainer: TOMURA Satoru <tomura@etl.go.jp>
 


### PR DESCRIPTION
Fix build after the removal of `make-coding-system`, which had been deprecated since 23.1 and removed with commit 874ba85363 to master branch of Emacs git repository.